### PR TITLE
Drop AWS instance lifecycle to avoid Tailscale node conflicts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,10 +56,6 @@ resource "aws_instance" "main" {
   ], var.extra_security_groups)
   user_data = local.user_data
   tags = { "Name" = local.common_name }
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_eip_association" "main" {


### PR DESCRIPTION
While replacing the EC2 instance with `lifecycle.create_before_destroy`, the new instance will attempt to register at the Tailscale control plane and due to the same hostname it will conflict and end up as `node-X`. This may leads to breakage on ACLs and advertised routes.

This change removes the lifecycle from the `aws_instance` resource, while this will lead to a short downtime of the tunnel, the tunnel will come back as soon as the new instance launches without any manual steps on the Tailscale admin UI.